### PR TITLE
feature/signup: 중개자 정보, 프로필 입력 화면 구현 및 로그인 로직 수정

### DIFF
--- a/core/designsystem/src/main/java/com/kusitms/connectdog/core/designsystem/component/Card.kt
+++ b/core/designsystem/src/main/java/com/kusitms/connectdog/core/designsystem/component/Card.kt
@@ -1,5 +1,6 @@
 package com.kusitms.connectdog.core.designsystem.component
 
+import androidx.annotation.StringRes
 import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -123,7 +124,9 @@ fun ConnectDogCardButton(
 }
 
 @Composable
-fun ConnectDogErrorCard() {
+fun ConnectDogErrorCard(
+    @StringRes errorMessage: Int
+) {
     Card(
         colors =
         CardDefaults.cardColors(
@@ -147,7 +150,7 @@ fun ConnectDogErrorCard() {
             )
             Spacer(modifier = Modifier.width(6.dp))
             Text(
-                text = stringResource(id = R.string.login_error),
+                text = stringResource(id = errorMessage),
                 color = Red1,
                 fontSize = 13.sp
             )

--- a/feature/login/src/main/java/com/kusitms/connectdog/feature/login/LoginNavigation.kt
+++ b/feature/login/src/main/java/com/kusitms/connectdog/feature/login/LoginNavigation.kt
@@ -46,19 +46,12 @@ fun NavGraphBuilder.loginNavGraph(
         NormalLoginScreen(
             onBackClick = onBackClick,
             type = it.arguments!!.getSerializable("type") as Type,
-            test = onNavigateToVolunteer
+            onNavigateToVolunteerHome = onNavigateToVolunteer
         )
-    }
-
-    composable(route = LoginRoute.signup) {
-//        SignUpSc(
-// //            onBackClick = onBackClick
-//        )
     }
 }
 
 object LoginRoute {
     const val route = "login"
     const val normal_login = "normal_login"
-    const val signup = "signup"
 }

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainNavigator.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainNavigator.kt
@@ -35,6 +35,7 @@ import com.kusitms.connectdog.feature.mypage.navigation.navigateMypage
 import com.kusitms.connectdog.feature.mypage.navigation.navigateNotification
 import com.kusitms.connectdog.feature.mypage.navigation.navigateSetting
 import com.kusitms.connectdog.signup.navigateCompleteSignUp
+import com.kusitms.connectdog.signup.navigateIntermediatorInformation
 import com.kusitms.connectdog.signup.navigateRegisterEmail
 import com.kusitms.connectdog.signup.navigateRegisterPassword
 import com.kusitms.connectdog.signup.navigateSelectProfileImage
@@ -90,7 +91,8 @@ internal class MainNavigator(
     fun navigateRegisterEmail(type: Type) = navController.navigateRegisterEmail(type)
     fun navigateRegisterPassword(type: Type) = navController.navigateRegisterPassword(type)
     fun navigateSelectProfileImage() = navController.navigateSelectProfileImage()
-    fun navigateCompleteSignUp() = navController.navigateCompleteSignUp()
+    fun navigateCompleteSignUp(type: Type) = navController.navigateCompleteSignUp(type)
+    fun navigateIntermediatorInformation() = navController.navigateIntermediatorInformation()
 
     // volunteer navigator
     fun navigateHome() = navigate(MainTab.HOME)

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainScreen.kt
@@ -68,13 +68,14 @@ internal fun MainScreen(
                     signUpGraph(
                         onBackClick = navigator::popBackStackIfNotHome,
                         navigateToVolunteerProfile = { navigator.navigateVolunteerProfile() },
+                        navigateToIntermediatorInformation = { navigator.navigateIntermediatorInformation() },
                         navigateToIntermediatorProfile = { navigator.navigateIntermediatorProfile() },
                         navigateToRegisterEmail = { navigator.navigateRegisterEmail(it) },
                         navigateToRegisterPassword = { navigator.navigateRegisterPassword(it) },
                         navigateToSelectProfileImage = { navigator.navigateSelectProfileImage() },
-                        navigateToCompleteSignUp = { navigator.navigateCompleteSignUp() },
-                        navigateToVolunteer = {},
-                        navigateToIntermediator = {},
+                        navigateToCompleteSignUp = { navigator.navigateCompleteSignUp(it) },
+                        navigateToVolunteer = { navigator.navigateHome() },
+                        navigateToIntermediator = { navigator.navigateManageAccount() },
                         viewModel = viewModel
                     )
                     homeNavGraph(

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/SignUpNavigation.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/SignUpNavigation.kt
@@ -10,6 +10,8 @@ import com.kusitms.connectdog.signup.screen.CompleteSignUpScreen
 import com.kusitms.connectdog.signup.screen.RegisterEmailScreen
 import com.kusitms.connectdog.signup.screen.RegisterPasswordScreen
 import com.kusitms.connectdog.signup.screen.SignUpRoute
+import com.kusitms.connectdog.signup.screen.intermediator.IntermediatorInformationScreen
+import com.kusitms.connectdog.signup.screen.intermediator.IntermediatorProfileScreen
 import com.kusitms.connectdog.signup.screen.volunteer.SelectProfileImageScreen
 import com.kusitms.connectdog.signup.screen.volunteer.VolunteerProfileScreen
 import com.kusitms.connectdog.signup.viewmodel.VolunteerProfileViewModel
@@ -34,18 +36,23 @@ fun NavController.navigateSelectProfileImage() {
     navigate(SignUpRoute.profile_image)
 }
 
-fun NavController.navigateCompleteSignUp() {
-    navigate(SignUpRoute.complete_signup)
+fun NavController.navigateCompleteSignUp(type: Type) {
+    navigate("${SignUpRoute.complete_signup}/$type")
+}
+
+fun NavController.navigateIntermediatorInformation() {
+    navigate(SignUpRoute.intermediator_information)
 }
 
 fun NavGraphBuilder.signUpGraph(
     onBackClick: () -> Unit,
     navigateToVolunteerProfile: () -> Unit,
     navigateToIntermediatorProfile: () -> Unit,
+    navigateToIntermediatorInformation: () -> Unit,
     navigateToRegisterEmail: (Type) -> Unit,
     navigateToRegisterPassword: (Type) -> Unit,
     navigateToSelectProfileImage: () -> Unit,
-    navigateToCompleteSignUp: () -> Unit,
+    navigateToCompleteSignUp: (Type) -> Unit,
     navigateToVolunteer: () -> Unit,
     navigateToIntermediator: () -> Unit,
     viewModel: VolunteerProfileViewModel
@@ -64,7 +71,7 @@ fun NavGraphBuilder.signUpGraph(
             onBackClick = onBackClick,
             type = it.arguments!!.getSerializable("type") as Type,
             navigateToVolunteerProfile = navigateToVolunteerProfile,
-            navigateToIntermediatorProfile = navigateToIntermediatorProfile,
+            navigateToIntermediatorInformation = navigateToIntermediatorInformation,
             navigateToRegisterEmail = navigateToRegisterEmail
         )
     }
@@ -86,7 +93,9 @@ fun NavGraphBuilder.signUpGraph(
     ) {
         RegisterPasswordScreen(
             onBackClick = onBackClick,
-            navigateToVolunteerProfile = navigateToVolunteerProfile
+            onNavigateToIntermediatorProfile = navigateToIntermediatorProfile,
+            onNavigateToVolunteerProfile = navigateToVolunteerProfile,
+            type = it.arguments!!.getSerializable("type") as Type
         )
     }
 
@@ -96,6 +105,20 @@ fun NavGraphBuilder.signUpGraph(
             onNavigateToSelectProfileImage = navigateToSelectProfileImage,
             onNavigateToCompleteSignUp = navigateToCompleteSignUp,
             viewModel = viewModel
+        )
+    }
+
+    composable(route = SignUpRoute.intermediator_profile) {
+        IntermediatorProfileScreen(
+            onBackClick = onBackClick,
+            navigateToCompleteSignUp = navigateToCompleteSignUp
+        )
+    }
+
+    composable(route = SignUpRoute.intermediator_information) {
+        IntermediatorInformationScreen(
+            onBackClick = onBackClick,
+            onNavigateToRegisterEmail = navigateToRegisterEmail
         )
     }
 
@@ -109,9 +132,14 @@ fun NavGraphBuilder.signUpGraph(
     }
 
     composable(
-        route = SignUpRoute.complete_signup
+        route = "${SignUpRoute.complete_signup}/{type}",
+        arguments = typeArgument
     ) {
-        CompleteSignUpScreen()
+        CompleteSignUpScreen(
+            type = it.arguments!!.getSerializable("type") as Type,
+            navigateToVolunteer = navigateToVolunteer,
+            navigateToIntermediator = navigateToIntermediator
+        )
     }
 }
 
@@ -119,6 +147,7 @@ object SignUpRoute {
     const val route = "sign_up"
     const val volunteer_profile = "volunteer_profile"
     const val intermediator_profile = "intermediator_profile"
+    const val intermediator_information = "intermediator_information"
     const val register_email = "register_email"
     const val register_password = "register_password"
     const val profile_image = "profile_image"

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/CompleteSignUpScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/CompleteSignUpScreen.kt
@@ -29,10 +29,13 @@ import androidx.compose.ui.unit.sp
 import com.kusitms.connectdog.core.designsystem.R
 import com.kusitms.connectdog.core.designsystem.component.ConnectDogNormalButton
 import com.kusitms.connectdog.core.designsystem.theme.ConnectDogTheme
+import com.kusitms.connectdog.core.util.Type
 
 @Composable
 fun CompleteSignUpScreen(
-    onClick: () -> Unit = {}
+    navigateToVolunteer: () -> Unit,
+    navigateToIntermediator: () -> Unit,
+    type: Type
 ) {
     val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
@@ -88,7 +91,10 @@ fun CompleteSignUpScreen(
                         placeable.place(0, 0)
                     }
                 },
-            onClick = onClick
+            onClick = when (type) {
+                Type.INTERMEDIATOR -> navigateToIntermediator
+                else -> navigateToVolunteer
+            }
         )
     }
 }
@@ -97,6 +103,10 @@ fun CompleteSignUpScreen(
 @Composable
 private fun test() {
     ConnectDogTheme {
-        CompleteSignUpScreen(onClick = {})
+        CompleteSignUpScreen(
+            type = Type.INTERMEDIATOR,
+            navigateToIntermediator = {},
+            navigateToVolunteer = {}
+        )
     }
 }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterEmailScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterEmailScreen.kt
@@ -95,7 +95,7 @@ fun RegisterEmailScreen(
             Spacer(modifier = Modifier.weight(1f))
             ConnectDogNormalButton(
                 content = "다음",
-                onClick = { onNavigateToRegisterPassword(Type.NORMAL_VOLUNTEER) },
+                onClick = { onNavigateToRegisterPassword(type) },
                 modifier =
                 Modifier
                     .fillMaxWidth()

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterPasswordScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterPasswordScreen.kt
@@ -34,13 +34,16 @@ import com.kusitms.connectdog.core.designsystem.theme.ConnectDogTheme
 import com.kusitms.connectdog.core.designsystem.theme.Gray3
 import com.kusitms.connectdog.core.designsystem.theme.Orange_40
 import com.kusitms.connectdog.core.designsystem.theme.PetOrange
+import com.kusitms.connectdog.core.util.Type
 import com.kusitms.connectdog.signup.viewmodel.RegisterPasswordViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
 fun RegisterPasswordScreen(
     onBackClick: () -> Unit,
-    navigateToVolunteerProfile: () -> Unit,
+    onNavigateToVolunteerProfile: () -> Unit,
+    onNavigateToIntermediatorProfile: () -> Unit,
+    type: Type,
     viewModel: RegisterPasswordViewModel = hiltViewModel()
 ) {
     val focusManager = LocalFocusManager.current
@@ -51,7 +54,10 @@ fun RegisterPasswordScreen(
     Scaffold(
         topBar = {
             ConnectDogTopAppBar(
-                titleRes = R.string.volunteer_signup,
+                titleRes = when (type) {
+                    Type.INTERMEDIATOR -> R.string.intermediator_signup
+                    else -> R.string.volunteer_signup
+                },
                 navigationType = TopAppBarNavigationType.BACK,
                 navigationIconContentDescription = "Navigation icon",
                 onNavigationClick = onBackClick
@@ -120,7 +126,10 @@ fun RegisterPasswordScreen(
                 },
                 onClick = {
                     if (isValidPassword == false && isValidConfirmPassword == false) {
-                        navigateToVolunteerProfile()
+                        when (type) {
+                            Type.INTERMEDIATOR -> onNavigateToIntermediatorProfile()
+                            else -> onNavigateToVolunteerProfile()
+                        }
                     }
                 }
             )
@@ -132,6 +141,6 @@ fun RegisterPasswordScreen(
 @Composable
 private fun Preview() {
     ConnectDogTheme {
-        RegisterPasswordScreen({}, {})
+        RegisterPasswordScreen({}, {}, {}, Type.INTERMEDIATOR)
     }
 }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/SignUpScreen.kt
@@ -52,7 +52,7 @@ import com.kusitms.connectdog.signup.viewmodel.TermsViewModel
 internal fun SignUpRoute(
     onBackClick: () -> Unit,
     navigateToVolunteerProfile: () -> Unit,
-    navigateToIntermediatorProfile: () -> Unit,
+    navigateToIntermediatorInformation: () -> Unit,
     navigateToRegisterEmail: (Type) -> Unit,
     type: Type
 ) {
@@ -61,7 +61,7 @@ internal fun SignUpRoute(
         type = type,
         navigateToVolunteerProfile = navigateToVolunteerProfile,
         navigateToRegisterEmail = navigateToRegisterEmail,
-        navigateToIntermediatorProfile = navigateToIntermediatorProfile
+        navigateToIntermediatorProfile = navigateToIntermediatorInformation
     )
 }
 
@@ -149,7 +149,7 @@ fun SignUpScreen(
                     when (type) {
                         Type.NORMAL_VOLUNTEER -> navigateToRegisterEmail(type)
                         Type.SOCIAL_VOLUNTEER -> navigateToVolunteerProfile()
-                        Type.INTERMEDIATOR -> {}
+                        Type.INTERMEDIATOR -> navigateToIntermediatorProfile()
                     }
                 } else {
                     val toast = Toast.makeText(context, "모든 약관에 동의해주세요", Toast.LENGTH_SHORT)

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/intermediator/IntermediatorInformationScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/intermediator/IntermediatorInformationScreen.kt
@@ -1,0 +1,89 @@
+package com.kusitms.connectdog.signup.screen.intermediator
+
+import android.annotation.SuppressLint
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogNormalButton
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogTextField
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogTopAppBar
+import com.kusitms.connectdog.core.designsystem.component.TopAppBarNavigationType
+import com.kusitms.connectdog.core.util.Type
+import com.kusitms.connectdog.feature.signup.R
+import com.kusitms.connectdog.signup.viewmodel.IntermediatorInformationViewModel
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun IntermediatorInformationScreen(
+    onBackClick: () -> Unit,
+    onNavigateToRegisterEmail: (Type) -> Unit,
+    viewModel: IntermediatorInformationViewModel = hiltViewModel()
+) {
+    val focusManager = LocalFocusManager.current
+    val interactionSource = remember { MutableInteractionSource() }
+
+    Scaffold(
+        topBar = {
+            ConnectDogTopAppBar(
+                titleRes = R.string.intermediator_signup,
+                navigationType = TopAppBarNavigationType.BACK,
+                onNavigationClick = onBackClick
+            )
+        }
+    ) {
+        Column(
+            modifier = Modifier
+                .padding(horizontal = 20.dp)
+                .clickable(
+                    onClick = { focusManager.clearFocus() },
+                    indication = null,
+                    interactionSource = interactionSource
+                )
+        ) {
+            Spacer(modifier = Modifier.height(80.dp))
+            Text(
+                text = "중개 회원 정보를\n입력해 주세요",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            ConnectDogTextField(
+                text = viewModel.name,
+                onTextChanged = { viewModel.updateName(it) },
+                label = "중개자명",
+                placeholder = "중개자 이름, 중개 단체명 입력"
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            ConnectDogTextField(
+                text = viewModel.name,
+                onTextChanged = { viewModel.updateName(it) },
+                label = "중개자명",
+                placeholder = "중개자 이름, 중개 단체명 입력"
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            ConnectDogNormalButton(
+                content = "다음",
+                onClick = { onNavigateToRegisterEmail(Type.INTERMEDIATOR) },
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(56.dp)
+            )
+            Spacer(modifier = Modifier.height(32.dp))
+        }
+    }
+}

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/intermediator/IntermediatorProfileScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/intermediator/IntermediatorProfileScreen.kt
@@ -1,0 +1,170 @@
+package com.kusitms.connectdog.signup.screen.intermediator
+
+import android.annotation.SuppressLint
+import android.graphics.Bitmap
+import android.graphics.ImageDecoder
+import android.net.Uri
+import androidx.activity.compose.rememberLauncherForActivityResult
+import androidx.activity.result.PickVisualMediaRequest
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogNormalButton
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogOutlinedButton
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogTextField
+import com.kusitms.connectdog.core.designsystem.component.ConnectDogTopAppBar
+import com.kusitms.connectdog.core.designsystem.component.TopAppBarNavigationType
+import com.kusitms.connectdog.core.designsystem.theme.PetOrange
+import com.kusitms.connectdog.core.util.Type
+import com.kusitms.connectdog.feature.signup.R
+import com.kusitms.connectdog.signup.viewmodel.IntermediatorProfileViewModel
+
+@SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
+@Composable
+fun IntermediatorProfileScreen(
+    onBackClick: () -> Unit,
+    navigateToCompleteSignUp: (Type) -> Unit,
+    viewModel: IntermediatorProfileViewModel = hiltViewModel()
+) {
+    val context = LocalContext.current
+
+    fun convertToBitmap(uri: Uri): Bitmap = ImageDecoder
+        .decodeBitmap(
+            ImageDecoder.createSource(context.contentResolver, uri)
+        )
+    var imageUri by remember { mutableStateOf<Uri?>(null) }
+    val photoPicker = rememberLauncherForActivityResult(
+        contract = ActivityResultContracts.PickVisualMedia(),
+        onResult = { imageUri = it }
+    )
+
+    Scaffold(
+        topBar = {
+            ConnectDogTopAppBar(
+                titleRes = R.string.intermediator_signup,
+                navigationType = TopAppBarNavigationType.BACK,
+                onNavigationClick = onBackClick
+            )
+        }
+    ) {
+        val focusManager = LocalFocusManager.current
+        val interactionSource = remember { MutableInteractionSource() }
+        val scrollState = rememberScrollState()
+
+        Column(
+            modifier = Modifier
+                .fillMaxSize()
+                .background(Color.White)
+                .padding(start = 20.dp, end = 20.dp, bottom = 32.dp)
+                .clickable(
+                    onClick = { focusManager.clearFocus() },
+                    indication = null,
+                    interactionSource = interactionSource
+                )
+                .verticalScroll(scrollState)
+        ) {
+            Spacer(modifier = Modifier.height(80.dp))
+            Text(
+                text = "프로필 정보를\n입력해주세요",
+                fontSize = 20.sp,
+                fontWeight = FontWeight.Bold
+            )
+            Spacer(modifier = Modifier.height(40.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                imageUri?.let {
+                    Image(
+                        bitmap = convertToBitmap(it).asImageBitmap(),
+                        modifier = Modifier
+                            .size(100.dp)
+                            .clip(CircleShape),
+                        contentDescription = ""
+                    )
+                } ?: run {
+                    Image(
+                        painter = painterResource(id = com.kusitms.connectdog.core.util.R.drawable.ic_profile_1),
+                        contentDescription = ""
+                    )
+                }
+            }
+            Spacer(modifier = Modifier.height(12.dp))
+            Row(
+                modifier = Modifier
+                    .fillMaxWidth(),
+                horizontalArrangement = Arrangement.Center
+            ) {
+                ConnectDogOutlinedButton(
+                    width = 105,
+                    height = 27,
+                    text = "프로필 사진 선택",
+                    padding = 5,
+                    onClick = {
+                        photoPicker.launch(
+                            PickVisualMediaRequest(ActivityResultContracts.PickVisualMedia.ImageOnly)
+                        )
+                    }
+                )
+            }
+            Spacer(modifier = Modifier.height(40.dp))
+            ConnectDogTextField(
+                text = viewModel.introduce,
+                onTextChanged = { viewModel.updateIntroduce(it) },
+                label = "한줄 소개",
+                placeholder = "소개 입력",
+                height = 130
+            )
+            ConnectDogTextField(
+                text = viewModel.introduce,
+                onTextChanged = { viewModel.updateIntroduce(it) },
+                label = "문의 받을 연락처",
+                placeholder = "문의받을 연락처를 입력해주세요.",
+                height = 200
+            )
+            Spacer(modifier = Modifier.weight(1f))
+            ConnectDogNormalButton(
+                content = "다음",
+                modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .height(56.dp),
+                color = PetOrange,
+                onClick = { navigateToCompleteSignUp(Type.INTERMEDIATOR) }
+            )
+        }
+    }
+}

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/VolunteerProfileScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/VolunteerProfileScreen.kt
@@ -34,6 +34,8 @@ import com.kusitms.connectdog.core.designsystem.component.TopAppBarNavigationTyp
 import com.kusitms.connectdog.core.designsystem.theme.Orange_40
 import com.kusitms.connectdog.core.designsystem.theme.PetOrange
 import com.kusitms.connectdog.core.designsystem.theme.Red1
+import com.kusitms.connectdog.core.util.Type
+import com.kusitms.connectdog.feature.signup.R
 import com.kusitms.connectdog.signup.viewmodel.VolunteerProfileViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -41,7 +43,7 @@ import com.kusitms.connectdog.signup.viewmodel.VolunteerProfileViewModel
 fun VolunteerProfileScreen(
     onBackClick: () -> Unit,
     onNavigateToSelectProfileImage: () -> Unit,
-    onNavigateToCompleteSignUp: () -> Unit,
+    onNavigateToCompleteSignUp: (Type) -> Unit,
     viewModel: VolunteerProfileViewModel
 ) {
     val focusManager = LocalFocusManager.current
@@ -52,7 +54,7 @@ fun VolunteerProfileScreen(
     Scaffold(
         topBar = {
             ConnectDogTopAppBar(
-                titleRes = com.kusitms.connectdog.core.designsystem.R.string.volunteer_signup,
+                titleRes = R.string.volunteer_signup,
                 navigationType = TopAppBarNavigationType.BACK,
                 navigationIconContentDescription = "Navigation icon",
                 onNavigationClick = onBackClick
@@ -82,7 +84,10 @@ fun VolunteerProfileScreen(
                     .fillMaxWidth(),
                 horizontalArrangement = Arrangement.Center
             ) {
-                Image(painter = painterResource(id = viewModel.getProfileImage()), contentDescription = "")
+                Image(
+                    painter = painterResource(id = viewModel.getProfileImageId()),
+                    contentDescription = "volunteer profile image"
+                )
             }
             Spacer(modifier = Modifier.height(12.dp))
             Row(
@@ -115,11 +120,9 @@ fun VolunteerProfileScreen(
                 }
             )
             Text(
-                text = when (isAvailableNickname) {
-                    true -> "사용할 수 있는 닉네임 입니다."
-                    false -> "이미 사용중인 닉네임 입니다."
-                    null -> ""
-                },
+                text = isAvailableNickname?.let {
+                    if (it) { "사용할 수 있는 닉네임 입니다." } else { "이미 사용중인 닉네임 입니다." }
+                } ?: run { "" },
                 color = when (isAvailableNickname) {
                     false -> Red1
                     else -> PetOrange
@@ -135,7 +138,7 @@ fun VolunteerProfileScreen(
                     .fillMaxWidth()
                     .height(56.dp),
                 color = if (selectedImageIndex != -1 && isAvailableNickname == true) { PetOrange } else { Orange_40 },
-                onClick = { if (selectedImageIndex != -1 && isAvailableNickname == true) onNavigateToCompleteSignUp() }
+                onClick = { if (selectedImageIndex != -1 && isAvailableNickname == true) onNavigateToCompleteSignUp(Type.NORMAL_VOLUNTEER) }
             )
         }
     }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/IntermediatorInformationViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/IntermediatorInformationViewModel.kt
@@ -1,0 +1,18 @@
+package com.kusitms.connectdog.signup.viewmodel
+
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class IntermediatorInformationViewModel @Inject constructor() : ViewModel() {
+    private val _name: MutableState<String> = mutableStateOf("")
+    val name: String
+        get() = _name.value
+
+    fun updateName(name: String) {
+        _name.value = name
+    }
+}

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/IntermediatorProfileViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/IntermediatorProfileViewModel.kt
@@ -1,0 +1,23 @@
+package com.kusitms.connectdog.signup.viewmodel
+
+import android.net.Uri
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.mutableStateOf
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+
+@HiltViewModel
+class IntermediatorProfileViewModel @Inject constructor() : ViewModel() {
+    private val _introduce: MutableState<String> = mutableStateOf("")
+    val introduce: String
+        get() = _introduce.value
+
+    fun updateIntroduce(introduce: String) {
+        _introduce.value = introduce
+    }
+
+    private val _uri: MutableState<Uri?> = mutableStateOf(null)
+    val uri: Uri?
+        get() = _uri.value
+}

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/VolunteerProfileViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/VolunteerProfileViewModel.kt
@@ -49,7 +49,7 @@ class VolunteerProfileViewModel @Inject constructor(
         _nickname.value = nickname
     }
 
-    fun getProfileImage(): Int {
+    fun getProfileImageId(): Int {
         return if (_selectedImageIndex.value == -1) {
             com.kusitms.connectdog.core.designsystem.R.drawable.ic_circle
         } else {

--- a/feature/signup/src/main/res/values/string.xml
+++ b/feature/signup/src/main/res/values/string.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="volunteer_signup">이동봉사자 회원가입</string>
+    <string name="intermediator_signup">이동봉사 중개 회원가입</string>
+</resources>


### PR DESCRIPTION
## Summary
중개자 정보, 프로필 입력 화면 구현 및 로그인 로직 수정

## Description
* 중개자 정보를 입력하기 위한 화면과 viewmodel을 구현하였습니다.
* 중개자 프로필을 입력하기 위한 화면과 viewmodel을 구현하였습니다.
* 이메일, 비밀번호 textfield에 사용되는 상태를 viewmodel로 이전
* 로그인 성공 여부에 대한 변수를 LiveData에서 StateFlow로 migration
* 로그인 성공시에도 에러 메세지가 표시되는 버그 수정

## Related Issue
#73 

## Sceenshot(option)
<img width="347" alt="image" src="https://github.com/PawWithU/ConnectDog-AOS/assets/63611804/408d5f8a-deaf-4f4c-b587-7edceb77355d">
