### PR TITLE
feature/signup: 일반 봉사자 회원가입 api 연결

### DIFF
--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/api/ApiService.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/api/ApiService.kt
@@ -1,5 +1,6 @@
 package com.kusitms.connectdog.core.data.api
 
+import com.kusitms.connectdog.core.data.api.model.DeleteAccountResponse
 import com.kusitms.connectdog.core.data.api.model.IsDuplicateNicknameResponse
 import com.kusitms.connectdog.core.data.api.model.LoginResponseItem
 import com.kusitms.connectdog.core.data.api.model.MyInfoResponseItem
@@ -20,7 +21,9 @@ import com.kusitms.connectdog.core.data.api.model.volunteer.BookmarkResponseItem
 import com.kusitms.connectdog.core.data.api.model.volunteer.EmailCertificationBody
 import com.kusitms.connectdog.core.data.api.model.volunteer.EmailCertificationResponseItem
 import com.kusitms.connectdog.core.data.api.model.volunteer.IsDuplicateNicknameBody
+import com.kusitms.connectdog.core.data.api.model.volunteer.NormalVolunteerSignUpBody
 import com.kusitms.connectdog.core.data.api.model.volunteer.NoticeDetailResponseItem
+import com.kusitms.connectdog.core.data.api.model.volunteer.SocialVolunteerSignUpBody
 import com.kusitms.connectdog.core.data.api.model.volunteer.UserInfoResponse
 import retrofit2.http.Body
 import retrofit2.http.DELETE
@@ -62,11 +65,20 @@ internal interface ApiService {
     /**
      * 회원가입
      */
-
     @POST("/volunteers/sign-up/email")
     suspend fun postEmail(
         @Body emailCertificationBody: EmailCertificationBody
     ): EmailCertificationResponseItem
+
+    @POST("/volunteers/sign-up")
+    suspend fun postNormalVolunteerSignUp(
+        @Body normalVolunteerSignUpBody: NormalVolunteerSignUpBody
+    ): Unit
+
+    @POST("/volunteers/sign-up/social")
+    suspend fun postSocialVolunteerSignUp(
+        @Body socialVolunteerSignUpBody: SocialVolunteerSignUpBody
+    )
 
     /**
      * 봉사관리
@@ -141,6 +153,9 @@ internal interface ApiService {
 
     @GET("/volunteers/my/bookmarks")
     suspend fun getBookmarkData(): List<BookmarkResponseItem>
+
+    @DELETE("/volunteers/my/delete")
+    suspend fun deleteAccount(): DeleteAccountResponse
 
     /**
      * 이동봉사자 > 공고 상세조회

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/api/model/volunteer/NormalVolunteerSignUpBody.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/api/model/volunteer/NormalVolunteerSignUpBody.kt
@@ -1,0 +1,9 @@
+package com.kusitms.connectdog.core.data.api.model.volunteer
+
+data class NormalVolunteerSignUpBody(
+    val email: String,
+    val password: String,
+    val nickname: String,
+    val profileImageNum: Int,
+    val isOptionAgr: Boolean = true
+)

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/api/model/volunteer/SocialVolunteerSignUpBody.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/api/model/volunteer/SocialVolunteerSignUpBody.kt
@@ -1,0 +1,7 @@
+package com.kusitms.connectdog.core.data.api.model.volunteer
+
+data class SocialVolunteerSignUpBody(
+    val nickname: String,
+    val profileImageNum: Int,
+    val isOptionAgr: Boolean = true
+)

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/SignUpRepository.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/SignUpRepository.kt
@@ -4,8 +4,10 @@ import com.kusitms.connectdog.core.data.api.model.IsDuplicateNicknameResponse
 import com.kusitms.connectdog.core.data.api.model.volunteer.EmailCertificationBody
 import com.kusitms.connectdog.core.data.api.model.volunteer.EmailCertificationResponseItem
 import com.kusitms.connectdog.core.data.api.model.volunteer.IsDuplicateNicknameBody
+import com.kusitms.connectdog.core.data.api.model.volunteer.NormalVolunteerSignUpBody
 
 interface SignUpRepository {
     suspend fun postNickname(nickname: IsDuplicateNicknameBody): IsDuplicateNicknameResponse
     suspend fun postEmail(email: EmailCertificationBody): EmailCertificationResponseItem
+    suspend fun postNormalVolunteerSignUp(signUp: NormalVolunteerSignUpBody): Unit
 }

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/SignUpRepositoryImpl.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/SignUpRepositoryImpl.kt
@@ -5,6 +5,7 @@ import com.kusitms.connectdog.core.data.api.model.IsDuplicateNicknameResponse
 import com.kusitms.connectdog.core.data.api.model.volunteer.EmailCertificationBody
 import com.kusitms.connectdog.core.data.api.model.volunteer.EmailCertificationResponseItem
 import com.kusitms.connectdog.core.data.api.model.volunteer.IsDuplicateNicknameBody
+import com.kusitms.connectdog.core.data.api.model.volunteer.NormalVolunteerSignUpBody
 import javax.inject.Inject
 
 internal class SignUpRepositoryImpl @Inject constructor(
@@ -16,5 +17,9 @@ internal class SignUpRepositoryImpl @Inject constructor(
 
     override suspend fun postEmail(email: EmailCertificationBody): EmailCertificationResponseItem {
         return api.postEmail(email)
+    }
+
+    override suspend fun postNormalVolunteerSignUp(signUp: NormalVolunteerSignUpBody) {
+        return api.postNormalVolunteerSignUp(signUp)
     }
 }

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainScreen.kt
@@ -35,6 +35,7 @@ import com.kusitms.connectdog.feature.login.loginNavGraph
 import com.kusitms.connectdog.feature.management.navigation.managementNavGraph
 import com.kusitms.connectdog.feature.mypage.navigation.mypageNavGraph
 import com.kusitms.connectdog.signup.signUpGraph
+import com.kusitms.connectdog.signup.viewmodel.SignUpViewModel
 import com.kusitms.connectdog.signup.viewmodel.VolunteerProfileViewModel
 import kotlinx.collections.immutable.toPersistentList
 
@@ -46,8 +47,9 @@ internal fun MainScreen(
     verifyCode: (String, (Boolean) -> Unit) -> Unit,
     imeHeight: Int
 ) {
-    val viewModel: VolunteerProfileViewModel = hiltViewModel()
+    val profileViewModel: VolunteerProfileViewModel = hiltViewModel()
     val applyViewModel: ApplyViewModel = hiltViewModel()
+    val signUpViewModel: SignUpViewModel = hiltViewModel()
 
     Scaffold(
         content = {
@@ -79,7 +81,8 @@ internal fun MainScreen(
                         navigateToVolunteer = { navigator.navigateHome() },
                         navigateToIntermediator = { navigator.navigateManageAccount() },
                         imeHeight = imeHeight,
-                        viewModel = viewModel
+                        signUpViewModel = signUpViewModel,
+                        profileViewModel = profileViewModel
                     )
                     homeNavGraph(
                         onBackClick = navigator::popBackStackIfNotHome,
@@ -106,10 +109,9 @@ internal fun MainScreen(
                     )
                     mypageNavGraph(
                         padding = it,
-                        onClick = {},
                         onLogoutClick = { navigator.onLogoutClick() },
                         onBackClick = navigator::popBackStackIfNotHome,
-                        onEditProfileClick = { navigator.navigateEditProfile() },
+                        onEditProfileClick = { nickname, index -> navigator.navigateEditProfile(nickname, index) },
                         onManageAccountClick = { navigator.navigateManageAccount() },
                         onNotificationClick = { navigator.navigateNotification() },
                         onSettingClick = { navigator.navigateSetting() },

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/SignUpNavigation.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/SignUpNavigation.kt
@@ -14,6 +14,7 @@ import com.kusitms.connectdog.signup.screen.intermediator.IntermediatorInformati
 import com.kusitms.connectdog.signup.screen.intermediator.IntermediatorProfileScreen
 import com.kusitms.connectdog.signup.screen.volunteer.SelectProfileImageScreen
 import com.kusitms.connectdog.signup.screen.volunteer.VolunteerProfileScreen
+import com.kusitms.connectdog.signup.viewmodel.SignUpViewModel
 import com.kusitms.connectdog.signup.viewmodel.VolunteerProfileViewModel
 
 fun NavController.navigateSignup(userType: UserType) {
@@ -60,7 +61,8 @@ fun NavGraphBuilder.signUpGraph(
     navigateToVolunteer: () -> Unit,
     navigateToIntermediator: () -> Unit,
     imeHeight: Int,
-    viewModel: VolunteerProfileViewModel
+    signUpViewModel: SignUpViewModel,
+    profileViewModel: VolunteerProfileViewModel
 ) {
     val userTypeArgument = listOf(
         navArgument("type") {
@@ -89,6 +91,7 @@ fun NavGraphBuilder.signUpGraph(
             onBackClick = onBackClick,
             userType = it.arguments!!.getSerializable("type") as UserType,
             onNavigateToRegisterPassword = navigateToRegisterPassword,
+            signUpViewModel = signUpViewModel,
             imeHeight = imeHeight
         )
     }
@@ -102,6 +105,7 @@ fun NavGraphBuilder.signUpGraph(
             onNavigateToIntermediatorProfile = navigateToIntermediatorProfile,
             onNavigateToVolunteerProfile = navigateToVolunteerProfile,
             userType = it.arguments!!.getSerializable("type") as UserType,
+            signUpViewModel = signUpViewModel,
             imeHeight = imeHeight
         )
     }
@@ -112,7 +116,8 @@ fun NavGraphBuilder.signUpGraph(
             onNavigateToSelectProfileImage = navigateToSelectProfileImage,
             onNavigateToCompleteSignUp = navigateToCompleteSignUp,
             imeHeight = imeHeight,
-            viewModel = viewModel
+            signUpViewModel = signUpViewModel,
+            viewModel = profileViewModel
         )
     }
 
@@ -137,7 +142,7 @@ fun NavGraphBuilder.signUpGraph(
     ) {
         SelectProfileImageScreen(
             onBackClick = onBackClick,
-            viewModel = viewModel
+            viewModel = profileViewModel
         )
     }
 

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterPasswordScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterPasswordScreen.kt
@@ -36,6 +36,7 @@ import com.kusitms.connectdog.core.designsystem.theme.Orange_40
 import com.kusitms.connectdog.core.designsystem.theme.PetOrange
 import com.kusitms.connectdog.core.util.UserType
 import com.kusitms.connectdog.signup.viewmodel.RegisterPasswordViewModel
+import com.kusitms.connectdog.signup.viewmodel.SignUpViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -45,6 +46,7 @@ fun RegisterPasswordScreen(
     onNavigateToIntermediatorProfile: () -> Unit,
     userType: UserType,
     imeHeight: Int,
+    signUpViewModel: SignUpViewModel,
     viewModel: RegisterPasswordViewModel = hiltViewModel()
 ) {
     val focusManager = LocalFocusManager.current
@@ -127,6 +129,7 @@ fun RegisterPasswordScreen(
                 },
                 onClick = {
                     if (isValidPassword == false && isValidConfirmPassword == false) {
+                        signUpViewModel.updatePassword(viewModel.password)
                         when (userType) {
                             UserType.INTERMEDIATOR -> onNavigateToIntermediatorProfile()
                             else -> onNavigateToVolunteerProfile()
@@ -143,6 +146,6 @@ fun RegisterPasswordScreen(
 @Composable
 private fun Preview() {
     ConnectDogTheme {
-        RegisterPasswordScreen({}, {}, {}, UserType.INTERMEDIATOR, 10)
+        RegisterPasswordScreen({}, {}, {}, UserType.INTERMEDIATOR, 10, hiltViewModel())
     }
 }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/VolunteerProfileScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/VolunteerProfileScreen.kt
@@ -1,6 +1,7 @@
 package com.kusitms.connectdog.signup.screen.volunteer
 
 import android.annotation.SuppressLint
+import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -36,6 +37,7 @@ import com.kusitms.connectdog.core.designsystem.theme.PetOrange
 import com.kusitms.connectdog.core.designsystem.theme.Red1
 import com.kusitms.connectdog.core.util.UserType
 import com.kusitms.connectdog.feature.signup.R
+import com.kusitms.connectdog.signup.viewmodel.SignUpViewModel
 import com.kusitms.connectdog.signup.viewmodel.VolunteerProfileViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
@@ -45,6 +47,7 @@ fun VolunteerProfileScreen(
     onNavigateToSelectProfileImage: () -> Unit,
     onNavigateToCompleteSignUp: (UserType) -> Unit,
     imeHeight: Int,
+    signUpViewModel: SignUpViewModel,
     viewModel: VolunteerProfileViewModel
 ) {
     val focusManager = LocalFocusManager.current
@@ -112,7 +115,10 @@ fun VolunteerProfileScreen(
                 textFieldLabel = "닉네임",
                 placeholder = "닉네임 입력",
                 buttonLabel = "중복 확인",
-                onClick = { viewModel.updateNicknameAvailability(it) },
+                onClick = {
+                    viewModel.isAvailableNickname()
+                    viewModel.updateNicknameAvailability(it)
+                },
                 onTextChanged = { viewModel.updateNickname(it) },
                 padding = 5,
                 isError = when (isAvailableNickname) {
@@ -139,7 +145,16 @@ fun VolunteerProfileScreen(
                     .fillMaxWidth()
                     .height(56.dp),
                 color = if (selectedImageIndex != -1 && isAvailableNickname == true) { PetOrange } else { Orange_40 },
-                onClick = { if (selectedImageIndex != -1 && isAvailableNickname == true) onNavigateToCompleteSignUp(UserType.NORMAL_VOLUNTEER) }
+                onClick = {
+                    if (selectedImageIndex != -1 && isAvailableNickname == true) {
+                        signUpViewModel.apply {
+                            this.updateNickname(viewModel.nickname)
+                            this.updateProfileImageId(viewModel.selectedImageIndex.value)
+                            this.postNormalVolunteerSignUp()
+                        }
+                        onNavigateToCompleteSignUp(UserType.NORMAL_VOLUNTEER)
+                    }
+                }
             )
             Spacer(modifier = Modifier.height((imeHeight + 32).dp))
         }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/VolunteerProfileScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/VolunteerProfileScreen.kt
@@ -1,7 +1,6 @@
 package com.kusitms.connectdog.signup.screen.volunteer
 
 import android.annotation.SuppressLint
-import android.util.Log
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
@@ -52,8 +51,9 @@ fun VolunteerProfileScreen(
 ) {
     val focusManager = LocalFocusManager.current
     val interactionSource = remember { MutableInteractionSource() }
-    val isAvailableNickname by viewModel.isAvailableNickname.collectAsState()
+    val isDuplicatedNickname by viewModel.isDuplicatedNickname.collectAsState()
     val selectedImageIndex by viewModel.selectedImageIndex.collectAsState()
+    val isAvailableNickname by viewModel.isAvailableNickname.collectAsState()
 
     Scaffold(
         topBar = {
@@ -116,23 +116,22 @@ fun VolunteerProfileScreen(
                 placeholder = "닉네임 입력",
                 buttonLabel = "중복 확인",
                 onClick = {
-                    viewModel.isAvailableNickname()
                     viewModel.updateNicknameAvailability(it)
                 },
-                onTextChanged = { viewModel.updateNickname(it) },
+                onTextChanged = {
+                    viewModel.updateNickname(it)
+                    viewModel.isAvailableNickname()
+                },
                 padding = 5,
-                isError = when (isAvailableNickname) {
-                    false -> true
-                    else -> false
-                }
+                isError = (isDuplicatedNickname ?: false) || (isAvailableNickname ?: false)
             )
             Text(
-                text = isAvailableNickname?.let {
-                    if (it) { "사용할 수 있는 닉네임 입니다." } else { "이미 사용중인 닉네임 입니다." }
+                text = isDuplicatedNickname?.let {
+                    if (it) { "이미 사용중인 닉네임 입니다." } else { "사용할 수 있는 닉네임 입니다." }
                 } ?: run { "" },
-                color = when (isAvailableNickname) {
-                    false -> Red1
-                    else -> PetOrange
+                color = when (isDuplicatedNickname) {
+                    false -> PetOrange
+                    else -> Red1
                 },
                 fontSize = 11.sp,
                 modifier = Modifier.padding(top = 4.dp, start = 8.dp)
@@ -144,9 +143,9 @@ fun VolunteerProfileScreen(
                 Modifier
                     .fillMaxWidth()
                     .height(56.dp),
-                color = if (selectedImageIndex != -1 && isAvailableNickname == true) { PetOrange } else { Orange_40 },
+                color = if (selectedImageIndex != -1 && isDuplicatedNickname == true) { PetOrange } else { Orange_40 },
                 onClick = {
-                    if (selectedImageIndex != -1 && isAvailableNickname == true) {
+                    if (selectedImageIndex != -1 && isDuplicatedNickname == true) {
                         signUpViewModel.apply {
                             this.updateNickname(viewModel.nickname)
                             this.updateProfileImageId(viewModel.selectedImageIndex.value)

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/RegisterEmailViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/RegisterEmailViewModel.kt
@@ -21,6 +21,10 @@ class RegisterEmailViewModel @Inject constructor(
     val isEmailVerified: StateFlow<Boolean>
         get() = _isEmailVerified
 
+    private val _isEmailDuplicated: MutableStateFlow<Boolean?> = MutableStateFlow(null)
+    val isEmailDuplicated: StateFlow<Boolean?>
+        get() = _isEmailDuplicated
+
     private val _isValidEmail: MutableStateFlow<Boolean?> = MutableStateFlow(null)
     val isValidEmail: StateFlow<Boolean?>
         get() = _isValidEmail
@@ -52,9 +56,10 @@ class RegisterEmailViewModel @Inject constructor(
             val body = EmailCertificationBody(_email.value)
             try {
                 val response = signUpRepository.postEmail(body)
+                _isEmailDuplicated.value = false
                 postNumber = response.authCode
             } catch (e: Exception) {
-                Log.d("asdf", e.message.toString())
+                _isEmailDuplicated.value = true
             }
         }
     }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/SignUpViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/SignUpViewModel.kt
@@ -1,0 +1,59 @@
+package com.kusitms.connectdog.signup.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kusitms.connectdog.core.data.api.model.volunteer.NormalVolunteerSignUpBody
+import com.kusitms.connectdog.core.data.repository.SignUpRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+@HiltViewModel
+class SignUpViewModel @Inject constructor(
+    private val signupRepository: SignUpRepository
+) : ViewModel() {
+    private val _email = MutableStateFlow<String?>(null)
+    val email: StateFlow<String?> = _email
+
+    private val _password = MutableStateFlow<String?>(null)
+    val password: StateFlow<String?> = _password
+
+    private val _nickname = MutableStateFlow<String?>(null)
+    val nickname: StateFlow<String?> = _nickname
+
+    private val _profileImageId = MutableStateFlow<Int?>(null)
+    val profileImageId: StateFlow<Int?> = _profileImageId
+
+    fun updateEmail(email: String) {
+        _email.value = email
+    }
+
+    fun updatePassword(password: String) {
+        _password.value = password
+    }
+
+    fun updateNickname(nickname: String) {
+        _nickname.value = nickname
+    }
+
+    fun updateProfileImageId(profileImageId: Int) {
+        _profileImageId.value = profileImageId
+    }
+
+    fun postNormalVolunteerSignUp() {
+        val body = NormalVolunteerSignUpBody(
+            email = email.value!!,
+            nickname = nickname.value!!,
+            password = password.value!!,
+            profileImageNum = profileImageId.value!!
+        )
+
+        viewModelScope.launch {
+            val response = signupRepository.postNormalVolunteerSignUp(body)
+            Log.d("tesaq", response.toString())
+        }
+    }
+}

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/VolunteerProfileViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/VolunteerProfileViewModel.kt
@@ -14,6 +14,8 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
+private const val TAG = "VolunteerProfileViewModel"
+
 @HiltViewModel
 class VolunteerProfileViewModel @Inject constructor(
     private val signupRepository: SignUpRepository
@@ -22,21 +24,33 @@ class VolunteerProfileViewModel @Inject constructor(
     val selectedImageIndex: StateFlow<Int>
         get() = _selectedImageIndex
 
-    private val _isNicknameAvailable: MutableStateFlow<Boolean?> = MutableStateFlow(null)
+    private val _isDuplicatedNickname: MutableStateFlow<Boolean?> = MutableStateFlow(null)
+    val isDuplicatedNickname: StateFlow<Boolean?>
+        get() = _isDuplicatedNickname
+
+    private val _isAvailableNickname: MutableStateFlow<Boolean?> = MutableStateFlow(null)
     val isAvailableNickname: StateFlow<Boolean?>
-        get() = _isNicknameAvailable
+        get() = _isAvailableNickname
 
     private val _nickname: MutableState<String> = mutableStateOf("")
     val nickname: String
         get() = _nickname.value
 
+    fun isAvailableNickname() {
+        val regex = Regex("[가-힣0-9]+")
+        _isAvailableNickname.value = !regex.matches(_nickname.value)
+        Log.d("taswa", _isAvailableNickname.value.toString())
+    }
+
     fun updateNicknameAvailability(nickname: String) {
         val nicknameBody = IsDuplicateNicknameBody(nickname = nickname)
         viewModelScope.launch {
             try {
-                _isNicknameAvailable.value = signupRepository.postNickname(nicknameBody).isDuplicated
+                val response = signupRepository.postNickname(nicknameBody)
+                Log.d(TAG, response.toString())
+                _isDuplicatedNickname.value = !response.isDuplicated
             } catch (e: Exception) {
-                Log.d("error", e.message.toString())
+                Log.d(TAG, e.message.toString())
             }
         }
     }


### PR DESCRIPTION
## Summary
일반 봉사자 회원가입 api 연결

## Description
* 일반 봉사자, 소셜 봉사자 dto 추가
* 일반 회원가입 api 함수 추가
* RegisterEmailScreen, RegisterPasswordScreen, VolunteerProfileScreen에서 입력 받은 데이터를 SignUpViewModel에서 관리해 회원가입 api 호출시 사용

## Related Issue
#85 

## Sceenshot(option)
