### PR TITLE
feature/mypage: 저장한 이동 봉사 공고 아이템을 클릭하면 상세 화면으로 이동할 수 있도록 구현

### DIFF
--- a/feature/home/src/main/java/com/kusitms/connectdog/feature/home/screen/DetailScreen.kt
+++ b/feature/home/src/main/java/com/kusitms/connectdog/feature/home/screen/DetailScreen.kt
@@ -60,7 +60,7 @@ private const val TAG = "DetailScreen"
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
-internal fun DetailScreen(
+fun DetailScreen(
     onBackClick: () -> Unit,
     onCertificationClick: (Long) -> Unit,
     onIntermediatorProfileClick: (Long) -> Unit,

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainScreen.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainScreen.kt
@@ -118,6 +118,9 @@ internal fun MainScreen(
                         onBookmarkClick = { navigator.navigateBookmark() },
                         onEditProfileImageClick = { navigator.navigateEditProfileImage() },
                         editProfileViewModel = editProfileViewModel,
+                        onNavigateToCertification = { navigator.navigateCertification(it) },
+                        onNavigateToDetail = { navigator.navigateHomeDetail(it) },
+                        onNavigateToIntermediatorProfile = { navigator.navigateIntermediatorInformation() },
                         onShowErrorSnackbar = {}
                     )
                 }

--- a/feature/mypage/build.gradle.kts
+++ b/feature/mypage/build.gradle.kts
@@ -51,6 +51,7 @@ dependencies {
     implementation(project(":core:data"))
     implementation(project(":core:designsystem"))
     implementation(project(":core:util"))
+    implementation(project(":feature:home"))
 
     kapt(libs.hilt.compiler)
     implementation(libs.hilt.android)

--- a/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/navigation/MypageNavigation.kt
+++ b/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/navigation/MypageNavigation.kt
@@ -4,7 +4,11 @@ import androidx.compose.foundation.layout.PaddingValues
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
+import androidx.navigation.NavType
 import androidx.navigation.compose.composable
+import androidx.navigation.navArgument
+import com.kusitms.connectdog.feature.home.navigation.HomeRoute
+import com.kusitms.connectdog.feature.home.screen.DetailScreen
 import com.kusitms.connectdog.feature.mypage.screen.BadgeScreen
 import com.kusitms.connectdog.feature.mypage.screen.BookmarkScreen
 import com.kusitms.connectdog.feature.mypage.screen.EditProfileScreen
@@ -59,7 +63,10 @@ fun NavGraphBuilder.mypageNavGraph(
     onBookmarkClick: () -> Unit,
     onShowErrorSnackbar: (throwable: Throwable?) -> Unit,
     onEditProfileImageClick: () -> Unit,
-    editProfileViewModel: EditProfileViewModel
+    editProfileViewModel: EditProfileViewModel,
+    onNavigateToIntermediatorProfile: (Long) -> Unit,
+    onNavigateToDetail: (Long) -> Unit,
+    onNavigateToCertification: (Long) -> Unit
 ) {
     composable(route = MypageRoute.route) {
         MypageRoute(
@@ -108,7 +115,8 @@ fun NavGraphBuilder.mypageNavGraph(
 
     composable(route = MypageRoute.bookmark) {
         BookmarkScreen(
-            onBackClick = onBackClick
+            onBackClick = onBackClick,
+            onDetailClick = onNavigateToDetail
         )
     }
 
@@ -116,6 +124,22 @@ fun NavGraphBuilder.mypageNavGraph(
         SelectProfileImageScreen(
             onBackClick = onBackClick,
             viewModel = editProfileViewModel
+        )
+    }
+
+    composable(
+        route = "${HomeRoute.detail}/{postId}",
+        arguments = listOf(
+            navArgument("postId") {
+                type = NavType.LongType
+            }
+        )
+    ) {
+        DetailScreen(
+            onBackClick = onBackClick,
+            onCertificationClick = { onNavigateToCertification(it) },
+            onIntermediatorProfileClick = onNavigateToIntermediatorProfile,
+            postId = it.arguments!!.getLong("postId")
         )
     }
 }

--- a/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/BookmarkScreen.kt
+++ b/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/BookmarkScreen.kt
@@ -1,6 +1,7 @@
 package com.kusitms.connectdog.feature.mypage.screen
 
 import android.annotation.SuppressLint
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
@@ -27,6 +28,7 @@ import com.kusitms.connectdog.feature.mypage.viewmodel.MyPageViewModel
 @Composable
 fun BookmarkScreen(
     onBackClick: () -> Unit,
+    onDetailClick: (Long) -> Unit,
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
     val bookmarkItem by viewModel.bookmark.observeAsState(null)
@@ -40,26 +42,34 @@ fun BookmarkScreen(
             )
         }
     ) {
-        bookmarkItem?.let { Content(it) }
+        bookmarkItem?.let { Content(it, onDetailClick) }
     }
 }
 
 @Composable
-private fun Content(item: List<BookmarkResponseItem>) {
+private fun Content(
+    item: List<BookmarkResponseItem>,
+    onDetailClick: (Long) -> Unit
+) {
     LazyColumn(
         modifier = Modifier.padding(top = 48.dp),
         verticalArrangement = Arrangement.Top
     ) {
         items(item) {
-            BookmarkContent(item = it)
+            BookmarkContent(item = it, onDetailClick = onDetailClick)
         }
     }
 }
 
 @Composable
-private fun BookmarkContent(item: BookmarkResponseItem) {
+private fun BookmarkContent(
+    item: BookmarkResponseItem,
+    onDetailClick: (Long) -> Unit
+) {
     ListForUserItem(
-        modifier = Modifier.padding(20.dp),
+        modifier = Modifier.padding(20.dp).clickable(
+            onClick = { onDetailClick(item.postId) }
+        ),
         imageUrl = item.mainImage,
         location = "${item.departureLoc} → ${item.arrivalLoc}",
         date = "${item.startDate} - ${item.endDate}",
@@ -73,6 +83,6 @@ private fun BookmarkContent(item: BookmarkResponseItem) {
 @Composable
 private fun Test() {
     ConnectDogTheme {
-        BookmarkScreen(onBackClick = {})
+        BookmarkScreen(onBackClick = {}, {})
     }
 }


### PR DESCRIPTION
## Summary
* 저장한 이동 봉사 공고 아이템을 클릭하면 상세 화면으로 이동할 수 있도록 구현

## Description
* 저장한 이동 봉사 공고 아이템을 클릭하면 상세 화면으로 이동할 수 있도록 구현

## Related Issue
#89 

## Sceenshot(option)
https://github.com/PawWithU/ConnectDog-AOS/assets/63611804/29037bc9-78df-4b4b-9f44-b60d64c2c55a

