### PR TITLE
feature/mypage: 마이페이지에서 수정된 정보가 반영되지 않는 문제 해결

### DIFF
--- a/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/BadgeScreen.kt
+++ b/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/BadgeScreen.kt
@@ -24,9 +24,9 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
@@ -79,7 +79,10 @@ fun BadgeScreen(
 ) {
     val showBottomSheet by viewModel.showBottomSheet.observeAsState(initial = false)
     val sheetState = rememberModalBottomSheetState()
-    val scope = rememberCoroutineScope()
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchBadge()
+    }
 
     Scaffold(
         topBar = {

--- a/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/BookmarkScreen.kt
+++ b/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/BookmarkScreen.kt
@@ -9,6 +9,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.material3.Divider
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Modifier
@@ -32,6 +33,10 @@ fun BookmarkScreen(
     viewModel: MyPageViewModel = hiltViewModel()
 ) {
     val bookmarkItem by viewModel.bookmark.observeAsState(null)
+
+    LaunchedEffect(Unit) {
+        viewModel.fetchBookmark()
+    }
 
     Scaffold(
         topBar = {

--- a/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/MypageScreen.kt
+++ b/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/screen/MypageScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.livedata.observeAsState
 import androidx.compose.ui.Alignment
@@ -96,12 +97,17 @@ private fun MypageScreen(
     onNotificationClick: () -> Unit,
     onSettingClick: () -> Unit,
     onBadgeClick: () -> Unit,
-    onBookmarkClick: () -> Unit
+    onBookmarkClick: () -> Unit,
+    viewModel: MyPageViewModel = hiltViewModel()
 ) {
+    LaunchedEffect(Unit) {
+        viewModel.fetchUserInfo()
+    }
+
     Column {
         TopBar(onSettingClick, onNotificationClick)
         Spacer(modifier = Modifier.height(20.dp))
-        MyInformation(onEditProfileClick)
+        MyInformation(onEditProfileClick, viewModel)
         Spacer(modifier = Modifier.height(20.dp))
         InformationBox()
         Spacer(modifier = Modifier.height(40.dp))
@@ -116,7 +122,7 @@ private fun MypageScreen(
 @Composable
 private fun MyInformation(
     onEditProfileClick: () -> Unit,
-    viewModel: MyPageViewModel = hiltViewModel()
+    viewModel: MyPageViewModel
 ) {
     val userInfo by viewModel.userInfo.observeAsState(null)
 

--- a/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/viewmodel/MyPageViewModel.kt
+++ b/feature/mypage/src/main/java/com/kusitms/connectdog/feature/mypage/viewmodel/MyPageViewModel.kt
@@ -21,10 +21,6 @@ private const val TAG = "MyPageViewModel"
 class MyPageViewModel @Inject constructor(
     private val myPageRepository: MyPageRepository
 ) : ViewModel() {
-    init {
-        fetchUserInfo()
-    }
-
     private val _myInfo = MutableLiveData<MyInfoResponseItem?>()
     val myInfo: LiveData<MyInfoResponseItem?> = _myInfo
 
@@ -43,23 +39,36 @@ class MyPageViewModel @Inject constructor(
     private val _badgeItem = MutableLiveData<BadgeItem>()
     val badgeItem: LiveData<BadgeItem> = _badgeItem
 
-    private fun fetchUserInfo() {
+    fun fetchUserInfo() {
         viewModelScope.launch {
             try {
                 val myInfoResponse = myPageRepository.getMyInfo()
                 val userInfoResponse = myPageRepository.getUserInfo()
-                val badgeResponse = myPageRepository.getBadge()
-                val bookmarkResponse = myPageRepository.getBookmarkData()
 
                 _myInfo.postValue(myInfoResponse)
                 _userInfo.postValue(userInfoResponse)
-                _badge.postValue(badgeResponse)
-                _bookmark.postValue(bookmarkResponse)
+            } catch (e: Exception) {
+                Log.d(TAG, e.message.toString())
+            }
+        }
+    }
 
-                Log.d(TAG, badgeResponse.toString())
-                Log.d(TAG, myInfoResponse.toString())
-                Log.d(TAG, userInfoResponse.toString())
-                Log.d(TAG, bookmarkResponse.toString())
+    fun fetchBookmark() {
+        viewModelScope.launch {
+            try {
+                val response = myPageRepository.getBadge()
+                _badge.postValue(response)
+            } catch (e: Exception) {
+                Log.d(TAG, e.message.toString())
+            }
+        }
+    }
+
+    fun fetchBadge() {
+        viewModelScope.launch {
+            try {
+                val response = myPageRepository.getBookmarkData()
+                _bookmark.postValue(response)
             } catch (e: Exception) {
                 Log.d(TAG, e.message.toString())
             }


### PR DESCRIPTION
## Summary
* 마이페이지에서 수정된 정보가 반영되지 않는 문제 해결

## Description
* 로그인, 프로필 이미지 변경 후 마이페이지로 돌아갔을때 api를 다시 호출하여 정보를 최신화하도록 수정
* 저장된 이동봉사 공고 화면으로 이동시 api를 다시 호출하여 정보를 최신화하도록 수정

## Related Issue
#95 

## Sceenshot(option)
