### PR TITLE
feature/signup: 회원가입 플로우 수정사항 반영#2

### DIFF
--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/SignUpNavigation.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/SignUpNavigation.kt
@@ -179,6 +179,7 @@ fun NavGraphBuilder.signUpGraph(
         CertificationScreen(
             onBackClick = onBackClick,
             onNavigateToRegisterEmail = navigateToRegisterEmail,
+            onNavigateToVolunteerProfile = navigateToVolunteerProfile,
             onSendMessageClick = onSendMessage,
             onVerifyCodeClick = onVerifyCode,
             imeHeight = imeHeight,

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterEmailScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/RegisterEmailScreen.kt
@@ -129,15 +129,18 @@ fun RegisterEmailScreen(
             Spacer(modifier = Modifier.weight(1f))
             ConnectDogNormalButton(
                 content = "다음",
-                color = if (isEmailVerified) { PetOrange } else { Orange_40 },
+                color = if (isEmailVerified) {
+                    PetOrange
+                } else {
+                    Orange_40
+                },
                 onClick = {
                     if (isEmailVerified) {
                         signUpViewModel.updateEmail(viewModel.email)
                         onNavigateToRegisterPassword(userType)
                     }
                 },
-                modifier =
-                Modifier
+                modifier = Modifier
                     .fillMaxWidth()
                     .height(56.dp)
             )
@@ -150,6 +153,12 @@ fun RegisterEmailScreen(
 @Composable
 private fun test() {
     ConnectDogTheme {
-        RegisterEmailScreen(onBackClick = {}, userType = UserType.NORMAL_VOLUNTEER, onNavigateToRegisterPassword = {}, hiltViewModel(), imeHeight = 10)
+        RegisterEmailScreen(
+            onBackClick = {},
+            userType = UserType.NORMAL_VOLUNTEER,
+            onNavigateToRegisterPassword = {},
+            hiltViewModel(),
+            imeHeight = 10
+        )
     }
 }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/SignUpScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/SignUpScreen.kt
@@ -32,7 +32,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalFocusManager
 import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.text.TextStyle
 import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.sp
 import androidx.hilt.navigation.compose.hiltViewModel
@@ -76,6 +78,7 @@ fun SignUpScreen(
 ) {
     val allChecked by viewModel.allChecked.observeAsState(initial = false)
     val privacyChecked by viewModel.privacyChecked.observeAsState(initial = false)
+    val advertisementChecked by viewModel.advertisementChecked.observeAsState(initial = false)
     val termsChecked by viewModel.termsChecked.observeAsState(initial = false)
     val context = LocalContext.current
 
@@ -119,25 +122,33 @@ fun SignUpScreen(
             Spacer(modifier = Modifier.height(40.dp))
 
             CustomCheckbox("모두 동의", allChecked) {
-                viewModel.toggleAllChecked()
-                viewModel.toggleTermsChecked()
-                viewModel.togglePrivacyChecked()
+                viewModel.updateAllChecked()
+                viewModel.updateTermsChecked()
+                viewModel.updatePrivacyChecked()
             }
 
             Spacer(modifier = Modifier.height(16.dp))
             HorizontalLine()
             Spacer(modifier = Modifier.height(16.dp))
             CustomCheckbox("[필수] 이용약관 동의", termsChecked) {
-                viewModel.toggleTermsChecked()
+                viewModel.updateTermsChecked()
             }
             Spacer(modifier = Modifier.height(16.dp))
             CustomCheckbox("[필수] 개인정보 수집 및 이용 동의", privacyChecked) {
-                viewModel.togglePrivacyChecked()
+                viewModel.updatePrivacyChecked()
+            }
+            Spacer(modifier = Modifier.height(16.dp))
+            CustomCheckbox("[선택] 광고성 정보 수신 동의", advertisementChecked) {
+                viewModel.updateAdvertisementChecked()
             }
         }
         ConnectDogNormalButton(
             content = "다음",
-            color = if (allChecked) { PetOrange } else { Orange_40 },
+            color = if (allChecked) {
+                PetOrange
+            } else {
+                Orange_40
+            },
             modifier =
             Modifier
                 .fillMaxWidth()
@@ -200,16 +211,21 @@ fun CustomCheckbox(text: String, checked: Boolean, onCheckedChange: (Boolean) ->
             ),
             contentDescription = "Custom Checkbox",
             tint = if (isChecked) MaterialTheme.colorScheme.primary else Gray4,
-            modifier = Modifier
-                .size(24.dp)
+            modifier = Modifier.size(24.dp)
         )
-
         Spacer(modifier = Modifier.width(12.dp))
-
         Text(
             text = text,
             fontSize = 14.sp,
-            fontWeight = FontWeight.Bold,
+            fontWeight = FontWeight.Medium,
+            color = if (isChecked) Color.Black else Gray2
+        )
+        Spacer(modifier = Modifier.weight(1f))
+        Text(
+            text = "보기",
+            style = TextStyle(textDecoration = TextDecoration.Underline),
+            fontSize = 14.sp,
+            fontWeight = FontWeight.Medium,
             color = if (isChecked) Color.Black else Gray2
         )
     }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/CeritificationScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/CeritificationScreen.kt
@@ -40,6 +40,7 @@ import com.kusitms.connectdog.signup.viewmodel.CertificationViewModel
 fun CertificationScreen(
     onBackClick: () -> Unit,
     onNavigateToRegisterEmail: (UserType) -> Unit,
+    onNavigateToVolunteerProfile: (UserType) -> Unit,
     onSendMessageClick: (String) -> Unit,
     onVerifyCodeClick: (String, (Boolean) -> Unit) -> Unit,
     imeHeight: Int,
@@ -61,6 +62,7 @@ fun CertificationScreen(
     ) {
         Content(
             onNavigateToRegisterEmail = { onNavigateToRegisterEmail(userType) },
+            onNavigateToVolunteerProfile = { onNavigateToVolunteerProfile(userType) },
             onSendMessageClick = onSendMessageClick,
             onVerifyCodeClick = onVerifyCodeClick,
             viewModel = viewModel,
@@ -75,6 +77,7 @@ private fun Content(
     imeHeight: Int,
     userType: UserType,
     onNavigateToRegisterEmail: (UserType) -> Unit,
+    onNavigateToVolunteerProfile: (UserType) -> Unit,
     onSendMessageClick: (String) -> Unit,
     onVerifyCodeClick: (String, (Boolean) -> Unit) -> Unit,
     viewModel: CertificationViewModel
@@ -170,7 +173,10 @@ private fun Content(
             onClick = {
                 if (viewModel.name.isNotEmpty() && isCertified) {
                     viewModel.postAdditionalAuth()
-                    onNavigateToRegisterEmail(userType)
+                    when(userType) {
+                        UserType.SOCIAL_VOLUNTEER -> onNavigateToVolunteerProfile(userType)
+                        else -> onNavigateToRegisterEmail(userType)
+                    }
                 }
             }
         )

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/CeritificationScreen.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/screen/volunteer/CeritificationScreen.kt
@@ -173,7 +173,7 @@ private fun Content(
             onClick = {
                 if (viewModel.name.isNotEmpty() && isCertified) {
                     viewModel.postAdditionalAuth()
-                    when(userType) {
+                    when (userType) {
                         UserType.SOCIAL_VOLUNTEER -> onNavigateToVolunteerProfile(userType)
                         else -> onNavigateToRegisterEmail(userType)
                     }

--- a/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/TermsViewModel.kt
+++ b/feature/signup/src/main/java/com/kusitms/connectdog/signup/viewmodel/TermsViewModel.kt
@@ -17,20 +17,27 @@ class TermsViewModel @Inject constructor() : ViewModel() {
     private val _privacyChecked = MutableLiveData(false)
     val privacyChecked: LiveData<Boolean> = _privacyChecked
 
-    fun toggleAllChecked() {
+    private val _advertisementChecked = MutableLiveData(false)
+    val advertisementChecked: LiveData<Boolean> = _advertisementChecked
+
+    fun updateAllChecked() {
         _allChecked.value = !_allChecked.value!!
         _termsChecked.value = !_allChecked.value!!
         _privacyChecked.value = !_allChecked.value!!
     }
 
-    fun toggleTermsChecked() {
+    fun updateTermsChecked() {
         _termsChecked.value = !_termsChecked.value!!
         updateAllCheckedState()
     }
 
-    fun togglePrivacyChecked() {
+    fun updatePrivacyChecked() {
         _privacyChecked.value = !_privacyChecked.value!!
         updateAllCheckedState()
+    }
+
+    fun updateAdvertisementChecked() {
+        _advertisementChecked.value = !_advertisementChecked.value!!
     }
 
     private fun updateAllCheckedState() {


### PR DESCRIPTION
## Summary
* 회원가입 플로우 수정사항 반영#2

## Description
* 약관 동의 항목 추가
* 약관 항목 텍스트 굵기 수정 (Bold -> Medium)
* 약관 보기 텍스트 추가 (클릭 이벤트 구현 x)
* 소셜 로그인 회원가입자는 번호 인증 후에 프로필 설정화면으로 이동하도록 수정 (이메일 인증, 비밀번호 설정은 건너뜀)

## Related Issue
#120 

## Sceenshot(option)
<img width="515" alt="image" src="https://github.com/PawWithU/ConnectDog-AOS/assets/63611804/05e60f8f-dd40-4eec-97e4-881217555a24">
