### PR TITLE
feature/fcm: 알림 권한 및 fcm 관련 설정

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET" />
+    <uses-permission android:name="android.permission.POST_NOTIFICATIONS"/>
 
     <application
         android:name=".ConnectDogApplication"
@@ -18,6 +19,14 @@
         <meta-data
             android:name="com.kakao.sdk.AppKey"
             android:value="@string/kakao_app_key" />
+
+        <service
+            android:name=".feature.main.FirebaseMessagingService"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="com.google.firebase.MESSAGING_EVENT" />
+            </intent-filter>
+        </service>
 
         <activity android:name="com.kakao.sdk.auth.AuthCodeHandlerActivity"
             android:exported="true"

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/api/ApiService.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/api/ApiService.kt
@@ -2,6 +2,7 @@ package com.kusitms.connectdog.core.data.api
 
 import com.kusitms.connectdog.core.data.api.model.AdditionalAuthBody
 import com.kusitms.connectdog.core.data.api.model.DeleteAccountResponse
+import com.kusitms.connectdog.core.data.api.model.FcmTokenRequestBody
 import com.kusitms.connectdog.core.data.api.model.IsDuplicateNicknameResponse
 import com.kusitms.connectdog.core.data.api.model.LoginResponseItem
 import com.kusitms.connectdog.core.data.api.model.MyInfoResponseItem
@@ -212,4 +213,12 @@ internal interface ApiService {
         @Query("page") page: Int?,
         @Query("size") size: Int?
     ): List<ReviewResponseItem>
+
+    /**
+     * fcm
+     */
+    @POST("/volunteers/fcm")
+    suspend fun postFcmToken(
+        @Body fcmToken: FcmTokenRequestBody
+    )
 }

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/api/model/FcmTokenRequestBody.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/api/model/FcmTokenRequestBody.kt
@@ -1,0 +1,5 @@
+package com.kusitms.connectdog.core.data.api.model
+
+data class FcmTokenRequestBody(
+    val fcmToken: String
+)

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/DataStoreRepository.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/DataStoreRepository.kt
@@ -23,6 +23,7 @@ class DataStoreRepository @Inject constructor(
     private object PreferenceKeys {
         val accessToken = stringPreferencesKey("access_token")
         val refreshToken = stringPreferencesKey("refresh_token")
+        val fcmToken = stringPreferencesKey("fcm_token")
         val appMode = stringPreferencesKey("app_mode")
     }
 
@@ -44,6 +45,12 @@ class DataStoreRepository @Inject constructor(
         }
     }
 
+    suspend fun saveFcmToken(fcmToken: String) {
+        context.dataStore.edit { preferences ->
+            preferences[PreferenceKeys.fcmToken] = fcmToken
+        }
+    }
+
     val accessTokenFlow: Flow<String?> = context.dataStore.data
         .map { preferences ->
             preferences[PreferenceKeys.accessToken]
@@ -60,5 +67,10 @@ class DataStoreRepository @Inject constructor(
     val refreshTokenFlow: Flow<String?> = context.dataStore.data
         .map { preferences ->
             preferences[PreferenceKeys.accessToken]
+        }
+
+    val fcmTokenFlow: Flow<String?> = context.dataStore.data
+        .map { preferences ->
+            preferences[PreferenceKeys.fcmToken]
         }
 }

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/HomeRepository.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/HomeRepository.kt
@@ -1,12 +1,14 @@
 package com.kusitms.connectdog.core.data.repository
 
+import com.kusitms.connectdog.core.data.api.model.FcmTokenRequestBody
 import com.kusitms.connectdog.core.model.Announcement
 import com.kusitms.connectdog.core.model.AnnouncementHome
 import com.kusitms.connectdog.core.model.Review
 
 interface HomeRepository {
+    suspend fun getReviewList(page: Int? = 0, size: Int? = 5): List<Review>
     suspend fun getAnnouncementList(): List<AnnouncementHome>
-
+    suspend fun postFcmToken(fcmToken: FcmTokenRequestBody)
     suspend fun getAnnouncementListWithFilter(
         postStatus: String? = null,
         departureLoc: String? = null,
@@ -20,6 +22,4 @@ interface HomeRepository {
         page: Int? = 0,
         size: Int? = 50
     ): List<Announcement>
-
-    suspend fun getReviewList(page: Int? = 0, size: Int? = 5): List<Review>
 }

--- a/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/HomeRepositoryImpl.kt
+++ b/core/data/src/main/java/com/kusitms/connectdog/core/data/repository/HomeRepositoryImpl.kt
@@ -1,6 +1,7 @@
 package com.kusitms.connectdog.core.data.repository
 
 import com.kusitms.connectdog.core.data.api.ApiService
+import com.kusitms.connectdog.core.data.api.model.FcmTokenRequestBody
 import com.kusitms.connectdog.core.data.mapper.toData
 import com.kusitms.connectdog.core.data.mapper.volunteer.toData
 import com.kusitms.connectdog.core.model.Announcement
@@ -48,5 +49,9 @@ internal class HomeRepositoryImpl @Inject constructor(
 
     override suspend fun getReviewList(page: Int?, size: Int?): List<Review> {
         return api.getReviewsHome(page ?: 0, size ?: 5).map { it.toData() }
+    }
+
+    override suspend fun postFcmToken(fcmToken: FcmTokenRequestBody) {
+        api.postFcmToken(fcmToken)
     }
 }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -72,6 +72,7 @@ dependencies {
 
     implementation(libs.firebase.bom)
     implementation(libs.firebase.auth.ktx)
+    implementation(libs.firebase.messaging)
     implementation(libs.google.service)
 
     implementation(libs.androidx.core.ktx)

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/FirebaseMessagingService.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/FirebaseMessagingService.kt
@@ -1,0 +1,9 @@
+package com.kusitms.connectdog.feature.main
+
+import com.google.firebase.messaging.FirebaseMessagingService
+
+class FirebaseMessagingService : FirebaseMessagingService() {
+    override fun onNewToken(p0: String) {
+        super.onNewToken(p0)
+    }
+}

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainActivity.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainActivity.kt
@@ -1,24 +1,33 @@
 package com.kusitms.connectdog.feature.main
 
+import android.Manifest
+import android.content.pm.PackageManager
+import android.os.Build
 import android.os.Bundle
 import android.util.Log
 import android.view.WindowManager
 import android.widget.Toast
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.result.contract.ActivityResultContracts
+import androidx.activity.viewModels
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableIntStateOf
 import androidx.compose.runtime.setValue
+import androidx.core.app.ActivityCompat
+import androidx.core.content.ContextCompat
 import androidx.core.splashscreen.SplashScreen.Companion.installSplashScreen
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsAnimationCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.lifecycle.lifecycleScope
+import com.google.android.gms.tasks.OnCompleteListener
 import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseException
 import com.google.firebase.auth.FirebaseAuth
 import com.google.firebase.auth.PhoneAuthCredential
 import com.google.firebase.auth.PhoneAuthProvider
+import com.google.firebase.messaging.FirebaseMessaging
 import com.kusitms.connectdog.core.data.repository.DataStoreRepository
 import com.kusitms.connectdog.core.designsystem.theme.ConnectDogTheme
 import dagger.hilt.android.AndroidEntryPoint
@@ -36,10 +45,13 @@ class MainActivity : ComponentActivity() {
     private lateinit var auth: FirebaseAuth
     private lateinit var verificationId: String
     private var imeHeight by mutableIntStateOf(0)
+    private val viewModel: MainViewModel by viewModels()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         FirebaseApp.initializeApp(this)
+        askNotificationPermission()
+        initializeFcmToken()
         auth = FirebaseAuth.getInstance()
 
         installSplashScreen()
@@ -138,6 +150,38 @@ class MainActivity : ComponentActivity() {
                 this@MainActivity.imeHeight = 0
             }
             ViewCompat.onApplyWindowInsets(view, windowInsets)
+        }
+    }
+
+    private fun initializeFcmToken() {
+        FirebaseMessaging.getInstance().token.addOnCompleteListener(
+            OnCompleteListener { task ->
+                if (!task.isSuccessful) return@OnCompleteListener
+                val token = task.result
+                viewModel.updateFcmToken(token)
+            }
+        )
+    }
+
+    private val requestPermissionLauncher = registerForActivityResult(
+        ActivityResultContracts.RequestPermission()
+    ) { isGranted ->
+        if (isGranted) {
+        } else {
+        }
+    }
+
+    private fun askNotificationPermission() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            if (ContextCompat.checkSelfPermission(this, Manifest.permission.POST_NOTIFICATIONS) != PackageManager.PERMISSION_GRANTED) {
+                if (ActivityCompat.shouldShowRequestPermissionRationale(this, Manifest.permission.POST_NOTIFICATIONS)) {
+                    // 이미 권한을 거절한 경우 권한 설정 화면으로 이동
+                } else {
+                    // 처음 권한 요청을 할 경우
+                    registerForActivityResult(ActivityResultContracts.RequestPermission()) {
+                    }.launch(Manifest.permission.POST_NOTIFICATIONS)
+                }
+            }
         }
     }
 }

--- a/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainViewModel.kt
+++ b/feature/main/src/main/java/com/kusitms/connectdog/feature/main/MainViewModel.kt
@@ -1,0 +1,19 @@
+package com.kusitms.connectdog.feature.main
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.kusitms.connectdog.core.data.repository.DataStoreRepository
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+private const val TAG = "MAIN_VIEWMODEL"
+
+@HiltViewModel
+class MainViewModel @Inject constructor(
+    private val dataStoreRepository: DataStoreRepository
+) : ViewModel() {
+    fun updateFcmToken(token: String) = viewModelScope.launch {
+        dataStoreRepository.saveFcmToken(token)
+    }
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ livedata = "1.3.1"
 
 googleService = "4.3.15"
 firebaseBom = "32.3.1"
+firebaseMessaging = "22.0.0"
 
 naverOauth = "5.8.0"
 kakaoOauth = "2.17.0"
@@ -57,7 +58,7 @@ androidx-lifecycle-runtimeCompose = { group = "androidx.lifecycle", name = "life
 androidx-lifecycle-viewModelCompose = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "androidxLifecycle" }
 androidx-lifecycle-viewModelKtx = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-ktx", version.ref = "androidxLifecycle" }
 androidx-activity-compose = { group = "androidx.activity", name = "activity-compose", version.ref = "androidxActivity" }
-androidx-core-splashscreen = {group = "androidx.core", name = "core-splashscreen", version.ref = "androidxSplash"}
+androidx-core-splashscreen = { group = "androidx.core", name = "core-splashscreen", version.ref = "androidxSplash" }
 androidx-datastore = { group = "androidx.datastore", name = "datastore-preferences", version.ref = "androidxDataStore" }
 
 androidx-compose-bom = { group = "androidx.compose", name = "compose-bom", version.ref = "androidxComposeBom" }
@@ -67,11 +68,11 @@ androidx-compose-ui-tooling = { group = "androidx.compose.ui", name = "ui-toolin
 androidx-compose-ui-tooling-preview = { group = "androidx.compose.ui", name = "ui-tooling-preview" }
 androidx-compose-ui-test-manifest = { group = "androidx.compose.ui", name = "ui-test-manifest" }
 androidx-compose-ui-test-junit4 = { group = "androidx.compose.ui", name = "ui-test-junit4" }
-androidx-compose-material = {group = "androidx.compose.material", name = "material", version.ref = "androidxComposeMaterial"}
+androidx-compose-material = { group = "androidx.compose.material", name = "material", version.ref = "androidxComposeMaterial" }
 androidx-compose-material3 = { group = "androidx.compose.material3", name = "material3", version.ref = "androidxComposeMaterial3" }
 androidx-compose-navigation = { group = "androidx.navigation", name = "navigation-compose", version.ref = "androidxComposeNavigation" }
 androidx-compose-navigation-test = { group = "androidx.navigation", name = "navigation-testing", version.ref = "androidxComposeNavigation" }
-androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "androidxComposeFoundation"}
+androidx-compose-foundation = { group = "androidx.compose.foundation", name = "foundation", version.ref = "androidxComposeFoundation" }
 androidx-compose-runtime-livedata = { group = "androidx.compose.runtime", name = "runtime-livedata", version.ref = "livedata" }
 
 hilt-core = { group = "com.google.dagger", name = "hilt-core", version.ref = "hilt" }
@@ -85,14 +86,13 @@ hilt-navigation-compose = { group = "androidx.hilt", name = "hilt-navigation-com
 
 okhttp-logging = { group = "com.squareup.okhttp3", name = "logging-interceptor", version.ref = "okhttp" }
 retrofit-core = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
-retrofit-converter-moshi = {group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit"}
-moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin"}
+retrofit-converter-moshi = { group = "com.squareup.retrofit2", name = "converter-moshi", version.ref = "retrofit" }
+moshi-kotlin = { group = "com.squareup.moshi", name = "moshi-kotlin", version.ref = "moshiKotlin" }
 retrofit-kotlin-serialization = { group = "com.jakewharton.retrofit", name = "retrofit2-kotlinx-serialization-converter", version.ref = "retrofitKotlinxSerializationJson" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
-kotlinx-collection-imuutable = {group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable"}
+kotlinx-collection-imuutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
 
-google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson"}
 
 landscapist-bom = { group = "com.github.skydoves", name = "landscapist-bom", version.ref = "landscapist" }
 landscapist-coil = { group = "com.github.skydoves", name = "landscapist-coil" }
@@ -105,13 +105,15 @@ accompanist-pager = { group = "com.google.accompanist", name = "accompanist-page
 accompanist-pager-indicators = { group = "com.google.accompanist", name = "accompanist-pager-indicators", version.ref = "accompanistPagerIndicators" }
 
 naver-oauth = { group = "com.navercorp.nid", name = "oauth", version.ref = "naverOauth" }
-kakao-oauth = { group = "com.kakao.sdk", name = "v2-user", version.ref="kakaoOauth" }
+kakao-oauth = { group = "com.kakao.sdk", name = "v2-user", version.ref = "kakaoOauth" }
 
-google-service = { group = "com.google.gms", name = "google-services", version.ref = "googleService"}
-firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom"}
+google-gson = { group = "com.google.code.gson", name = "gson", version.ref = "gson" }
+google-service = { group = "com.google.gms", name = "google-services", version.ref = "googleService" }
+firebase-bom = { group = "com.google.firebase", name = "firebase-bom", version.ref = "firebaseBom" }
+firebase-messaging = { group = "com.google.firebase", name = "firebase-messaging", version.ref = "firebaseMessaging" }
 
 # modular graph
-dependency-graph = {group = "com.vanniktech", name = "gradle-dependency-graph-generator-plugin", version.ref = "dependencyGraph"}
+dependency-graph = { group = "com.vanniktech", name = "gradle-dependency-graph-generator-plugin", version.ref = "dependencyGraph" }
 
 # test
 junit = { group = "junit", name = "junit", version.ref = "junit" }
@@ -129,9 +131,9 @@ org-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.re
 com-android-library = { id = "com.android.library", version.ref = "agp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
-ktlint = {id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint"}
+ktlint = { id = "org.jlleitschuh.gradle.ktlint", version.ref = "ktlint" }
 org-jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "org-jetbrains-kotlin-jvm" }
-google-services = { id = "com.google.gms.google-services", version.ref = "googleService"}
+google-services = { id = "com.google.gms.google-services", version.ref = "googleService" }
 
 
 [bundles]


### PR DESCRIPTION
## Summary
알림 권한 및 fcm 관련 설정

## Description
* `manifest`에서 알림 권한, `FirebaseMessagingService` 선언
* `MainActivity`의 onCreate에서 알림 권한을 획득하는 로직 추가
* MainActivity에서 fcm 토큰을 초기화하고 DataStore에 저장 한 뒤 로그인하고 홈에 진입하는 시점에 백엔드로 post

## Related Issue
#136 

## Sceenshot(option)

